### PR TITLE
PR to fix build errors on Raspberry Pi3 B+ Ubuntu 20.04 LTS Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center"> <img src="https://raw.githubusercontent.com/qeeqbox/chameleon/master/readme/chameleonlogo.png"></p>
 
+## Note: If you want to deploy this on a Raspberry Pi 3B+ make sure you setup zram first to avoid lockups.
+
+GitHub: https://github.com/Nefelim4ag/systemd-swap
+
 #
 [![Generic badge](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/qeeqbox/chameleon/master/info&label=version&query=$.version&colorB=blue&style=flat-square)](https://github.com/qeeqbox/chameleon/blob/master/changes.md) [![Generic badge](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/qeeqbox/chameleon/master/info&label=build&query=$.dockercomposebuild&colorB=green&style=flat-square)](https://github.com/qeeqbox/chameleon/blob/master/changes.md) [![Generic badge](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/qeeqbox/chameleon/master/info&label=test&query=$.automatedtest&colorB=green&style=flat-square)](https://github.com/qeeqbox/chameleon/blob/master/changes.md) [![Generic badge](https://img.shields.io/static/v1?label=%F0%9F%91%8D&message=!&color=yellow&style=flat-square)](https://github.com/qeeqbox/chameleon/stargazers)
 

--- a/honeypot/Dockerfile
+++ b/honeypot/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update -y && apt-get install -y iptables-persistent tcpdump nmap iputils-ping python python-pip python-psycopg2 lsof psmisc dnsutils
+RUN apt-get update -y && apt-get install -y iptables-persistent tcpdump nmap iputils-ping python python-pip python-psycopg2 lsof psmisc dnsutils libffi-dev libssl-dev
 RUN pip install scapy netifaces pyftpdlib sqlalchemy pyyaml paramiko==2.7.1 impacket twisted rdpy==1.3.2 psutil requests redis mysql-connector-python
 RUN pip install -U requests[socks]
 RUN pip install -Iv rsa==4.0


### PR DESCRIPTION
Adding the following packages fixes the build errors.

* libffi-dev
* libssl-dev