### PR TITLE
fixed : Unable to locate package python-psycopg2

### DIFF
--- a/node-Dockerfile
+++ b/node-Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8
-RUN apt-get update -y && apt-get install -y tcpdump nmap iputils-ping python-psycopg2 lsof psmisc dnsutils curl ftp smbclient ssh telnet xtightvncviewer xvfb
+RUN apt-get update -y && apt-get install -y tcpdump nmap iputils-ping libpq-dev python3-psycopg2 lsof psmisc dnsutils curl ftp smbclient ssh telnet xtightvncviewer xvfb
 RUN pip3 install honeypots==0.28
 WORKDIR app
 COPY config.json .


### PR DESCRIPTION
updated psycopg2 to campatible with python3 and also install libpq-dev as psycopg2 requeirment