### PR TITLE
fix(grafana/Dockerfile): prefix image path with `docker.io/`

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:7.5.7
+FROM docker.io/grafana/grafana:7.5.7
 COPY ./postgres.yml /etc/grafana/provisioning/datasources/postgres.yml
 COPY ./dashboards.yml /etc/grafana/provisioning/dashboards/dashboards.yml
 COPY ./chameleon.json /var/lib/grafana/dashboards/chameleon.json


### PR DESCRIPTION
Hi, can I change `grafana/grafana:7.5.7` to `docker.io/grafana/grafana:7.5.7`?

Because when I use Podman, there are 4 different URLs to pull Grafana image:
```
$ podman image pull grafana/grafana:7.5.7
? Please select an image: 
  ▸ registry.fedoraproject.org/grafana/grafana:7.5.7
    registry.access.redhat.com/grafana/grafana:7.5.7
    docker.io/grafana/grafana:7.5.7
    quay.io/grafana/grafana:7.5.7
```